### PR TITLE
Add required ServerSideRender js dependency

### DIFF
--- a/includes/output/class-scriptlesssocialsharing-output-block.php
+++ b/includes/output/class-scriptlesssocialsharing-output-block.php
@@ -112,7 +112,7 @@ class ScriptlessSocialSharingOutputBlock extends ScriptlessSocialSharingOutputSh
 		wp_register_script(
 			$this->block . '-block',
 			plugin_dir_url( dirname( __FILE__ ) ) . "js/block{$minify}.js",
-			array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-block-editor' ),
+			array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-block-editor', 'wp-server-side-render' ),
 			$version,
 			false
 		);


### PR DESCRIPTION
The issue appears on the widgets screen when the block editor is enabled. In some situations, the block.js file may be loaded before server-side-render.js has been loaded. It breaks the component and stops it from being rendered.