### PR TITLE
Fix PHP 8.3 compatibility issues and WordPress 6.7 textdomain loading

### DIFF
--- a/includes/buttons/class-scriptlesssocialsharing-button-email.php
+++ b/includes/buttons/class-scriptlesssocialsharing-button-email.php
@@ -36,7 +36,7 @@ class ScriptlessSocialSharingButtonEmail extends ScriptlessSocialSharingButton {
 	 * @return string can be modified via filter
 	 */
 	protected function email_body() {
-		return apply_filters( 'scriptlesssocialsharing_email_body', $this->setting['email_body'] );
+		return apply_filters( 'scriptlesssocialsharing_email_body', $this->setting['email_body'] ?? '' );
 	}
 
 	/**
@@ -44,6 +44,6 @@ class ScriptlessSocialSharingButtonEmail extends ScriptlessSocialSharingButton {
 	 * @return string can be modified via filter
 	 */
 	protected function email_subject() {
-		return apply_filters( 'scriptlesssocialsharing_email_subject', $this->setting['email_subject'] );
+		return apply_filters( 'scriptlesssocialsharing_email_subject', $this->setting['email_subject'] ?? '' );
 	}
 }

--- a/includes/buttons/class-scriptlesssocialsharing-button-linkedin.php
+++ b/includes/buttons/class-scriptlesssocialsharing-button-linkedin.php
@@ -37,4 +37,14 @@ class ScriptlessSocialSharingButtonLinkedin extends ScriptlessSocialSharingButto
 	protected function get_url_base() {
 		return 'https://www.linkedin.com/shareArticle';
 	}
+
+	/**
+	 * Override parent description method to ensure string return.
+	 * 
+	 * @param string $description Optional description text
+	 * @return string
+	 */
+	protected function description( $description = '' ) {
+		return parent::description( $description ) ?? '';
+	}
 }

--- a/includes/buttons/class-scriptlesssocialsharing-button-pinterest.php
+++ b/includes/buttons/class-scriptlesssocialsharing-button-pinterest.php
@@ -42,12 +42,14 @@ class ScriptlessSocialSharingButtonPinterest extends ScriptlessSocialSharingButt
 	 * @return string
 	 */
 	protected function get_pinterest_description() {
-		$description   = $this->attributes['title'];
-		$pinterest_alt = get_post_meta( get_the_ID(), '_scriptlesssocialsharing_description', true );
-		$image         = $this->attributes['image'];
+		$description   = $this->attributes['title'] ?? '';
+		$pinterest_alt = get_post_meta( get_the_ID(), '_scriptlesssocialsharing_description', true ) ?? '';
+		$image         = $this->attributes['image'] ?? '';
+
+		// If no custom description, try getting alt text from Pinterest image
 		if ( ! $pinterest_alt && $this->pinterest_image() ) {
 			$image         = $this->pinterest_image();
-			$pinterest_alt = get_post_meta( $image, '_wp_attachment_image_alt', true );
+			$pinterest_alt = get_post_meta( $image, '_wp_attachment_image_alt', true ) ?? '';
 		}
 
 		if ( $pinterest_alt ) {

--- a/includes/buttons/class-scriptlesssocialsharing-button-twitter.php
+++ b/includes/buttons/class-scriptlesssocialsharing-button-twitter.php
@@ -45,12 +45,12 @@ class ScriptlessSocialSharingButtonTwitter extends ScriptlessSocialSharingButton
 	 * @return mixed|void|null
 	 */
 	private function get_twitter_title( $title ) {
-		$yoast = get_post_meta( get_the_ID(), '_yoast_wpseo_twitter-title', true );
+		$yoast = get_post_meta( get_the_ID(), '_yoast_wpseo_twitter-title', true ) ?? '';
 		if ( $yoast ) {
 			$title = $yoast;
 		}
 
-		return apply_filters( 'scriptlesssocialsharing_twitter_text', $title );
+		return apply_filters( 'scriptlesssocialsharing_twitter_text', $title ?? '' );
 	}
 
 	/**

--- a/includes/class-scriptlesssocialsharing-enqueue.php
+++ b/includes/class-scriptlesssocialsharing-enqueue.php
@@ -81,7 +81,7 @@ class ScriptlessSocialSharingEnqueue {
 	 * @since 2.4.0
 	 */
 	protected function load_fontawesome_font() {
-		if ( ! $this->enabled ) {
+		if ( !$this->enabled || empty($this->setting['styles']['font'] ?? false) ) {
 			return;
 		}
 		$fontawesome = apply_filters( 'scriptlesssocialsharing_use_fontawesome', true );

--- a/includes/class-scriptlesssocialsharing.php
+++ b/includes/class-scriptlesssocialsharing.php
@@ -103,9 +103,11 @@ class ScriptlessSocialSharing {
 	 * Set up text domain for translations
 	 *
 	 * @since 1.0.0
+	 * @deprecated 3.2.5 Moved to main plugin file
 	 */
 	public function load_textdomain() {
-		load_plugin_textdomain( 'scriptless-social-sharing' );
+		// Deprecated - textdomain is now loaded in the main plugin file
+		return;
 	}
 
 	/**

--- a/includes/output/class-scriptlesssocialsharing-output-attributes.php
+++ b/includes/output/class-scriptlesssocialsharing-output-attributes.php
@@ -61,15 +61,10 @@ class ScriptlessSocialSharingOutputAttributes {
 	 * @return string
 	 */
 	protected function title() {
-		$title = the_title_attribute(
-			array(
-				'echo' => false,
-			)
-		);
+		$title = the_title_attribute( array( 'echo' => false ) ) ?? '';
 		if ( $title ) {
 			$title = html_entity_decode( $title );
 		}
-
 		return apply_filters( 'scriptlesssocialsharing_posttitle', $title );
 	}
 

--- a/includes/output/class-scriptlesssocialsharing-output-block.php
+++ b/includes/output/class-scriptlesssocialsharing-output-block.php
@@ -47,6 +47,14 @@ class ScriptlessSocialSharingOutputBlock extends ScriptlessSocialSharingOutputSh
 	 * @return string
 	 */
 	public function render( $atts ) {
+		$defaults = array(
+			'networks' => array(),
+			'style' => '',
+			'heading' => '',
+			'buttons' => array(),
+			'post_id' => 0
+		);
+		$atts = shortcode_atts( $defaults, $atts );
 		$atts = $this->parse_networks( $atts );
 
 		$output  = '<div class="' . esc_attr( implode( ' ', $this->get_block_classes( $atts ) ) ) . '">';

--- a/includes/output/class-scriptlesssocialsharing-output-buttons.php
+++ b/includes/output/class-scriptlesssocialsharing-output-buttons.php
@@ -65,8 +65,8 @@ class ScriptlessSocialSharingOutputButtons extends ScriptlessSocialSharingOutput
 		if ( isset( $this->buttons ) && is_singular() ) {
 			return $this->buttons;
 		}
-		$buttons     = $this->get_all_buttons();
-		$set_buttons = $this->get_setting( 'buttons' );
+		$buttons     = (array)$this->get_all_buttons();
+		$set_buttons = (array)$this->get_setting( 'buttons' );
 		if ( $set_buttons ) {
 			foreach ( $buttons as $key => $value ) {
 				if ( empty( $set_buttons[ $value['name'] ] ) ) {

--- a/includes/postmeta/class-scriptlesssocialsharing-postmeta.php
+++ b/includes/postmeta/class-scriptlesssocialsharing-postmeta.php
@@ -90,7 +90,10 @@ class ScriptlessSocialSharingPostMeta {
 	 */
 	public function do_metabox( $post ) {
 		wp_nonce_field( 'scriptlesssocialsharing_post_save', 'scriptlesssocialsharing_post_nonce' );
-		include_once 'class-scriptlesssocialsharing-postmeta-fields.php';
+		$file_path = plugin_dir_path(__FILE__) . 'class-scriptlesssocialsharing-postmeta-fields.php';
+		if (file_exists($file_path)) {
+			include_once $file_path;
+		}
 		$fields_class = new ScriptlessSocialSharingPostMetaFields( $post->ID );
 		$fields       = $this->get_fields();
 		foreach ( $fields as $field ) {

--- a/includes/settings/class-scriptlesssocialsharing-settings.php
+++ b/includes/settings/class-scriptlesssocialsharing-settings.php
@@ -117,21 +117,21 @@ class ScriptlessSocialSharingSettings {
 	 * @return array
 	 */
 	public function get_setting( $key = '' ) {
-		if ( isset( $this->setting ) ) {
-			return $key ? $this->setting[ $key ] : $this->setting;
+		$db_setting = $this->get_database_setting();
+		if (!is_array($db_setting)) {
+			$db_setting = [];
 		}
-		$db_setting    = $this->get_database_setting();
-		$defaults      = $this->defaults();
+		$defaults = $this->defaults();
 		$this->setting = wp_parse_args( $db_setting, $defaults );
-		if ( empty( $db_setting['css_style'] ) && isset( $db_setting['styles']['font_css'] ) ) {
+		if ( empty( $this->setting['css_style'] ) && isset( $this->setting['styles']['font_css'] ) ) {
 			$this->setting['css_style'] = 'table';
 		}
-		if ( empty( $db_setting['icons'] ) && ! empty( $db_setting['styles'] ) ) {
-			$this->setting['icons'] = $db_setting['styles']['font_css'] ? 'font' : 'none';
+		if ( empty( $this->setting['icons'] ) && ! empty( $this->setting['styles'] ) ) {
+			$this->setting['icons'] = $this->setting['styles']['font_css'] ? 'font' : 'none';
 			unset( $this->setting['styles']['font_css'] );
 		}
 
-		return $key ? $this->setting[ $key ] : $this->setting;
+		return $key ? ($this->setting[$key] ?? null) : $this->setting;
 	}
 
 	/**

--- a/scriptless-social-sharing.php
+++ b/scriptless-social-sharing.php
@@ -31,6 +31,21 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+add_action( 'init', 'scriptlesssocialsharing_load_textdomain' );
+
+/**
+ * Load plugin textdomain.
+ *
+ * @since 3.2.5
+ */
+function scriptlesssocialsharing_load_textdomain() {
+	load_plugin_textdomain( 
+		'scriptless-social-sharing', 
+		false, 
+		dirname( plugin_basename( __FILE__ ) ) . '/languages' 
+	);
+}
+
 if ( ! defined( 'SCRIPTLESSOCIALSHARING_BASENAME' ) ) {
 	define( 'SCRIPTLESSOCIALSHARING_BASENAME', plugin_basename( __FILE__ ) );
 }


### PR DESCRIPTION
There are some errors showing after PHP 8.3 that gave "html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated" errors and caused issues with the button sizes being too large in the Customize admin overlay. These should fix them.

Should also help fix the error "PHP Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the scriptless-social-sharing domain was triggered too early." experienced by another user.

Needs testing, might need a few more tweaks too. None of the versioning was updated.