### PR TITLE
filter_allowed_protocols: change did_action to use template_redirect

### DIFF
--- a/includes/class-scriptlesssocialsharing.php
+++ b/includes/class-scriptlesssocialsharing.php
@@ -130,7 +130,7 @@ class ScriptlessSocialSharing {
 	 * @return mixed
 	 */
 	public function filter_allowed_protocols( $protocols ) {
-		if ( ! did_action( 'init' ) ) {
+		if ( ! did_action( 'template_redirect' ) ) {
 			return $protocols;
 		}
 


### PR DESCRIPTION
I have came across compatibility issue (php memory hitting the limit) between Branda login module (it basically improves the look of login page) and Scriptless Social Sharing.

This PR changes the `did_action` in `ScriptlessSocialSharing::filter_allowed_protocols`, so it uses `template_redirect` instead of `init`. This should overall increase the compatibility with other plugins. 